### PR TITLE
fix: add exclusion for symlinks in IOS build

### DIFF
--- a/packages/flutter_pjsip/build.yaml
+++ b/packages/flutter_pjsip/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    sources:
+      exclude:
+        # Exclude symlinks for the IOS build
+        - example/ios/.symlinks


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Due to a [bug](https://github.com/google/json_serializable.dart/issues/1285) [in](https://github.com/dart-lang/build/issues/3464) build_runner we forced to exclude `.symlinks` directory from codegen traverse.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
